### PR TITLE
drop the msp430.sh shim

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,11 +1,6 @@
 [target.msp430]
 rustflags = [
-  "-C",
-  "linker=./msp-gcc.sh",
-  "-C",
-  "link-arg=-Lldscripts",
-  "-C",
-  "link-arg=-Tmsp430g2553.ld",
-  "-C",
-  "link-arg=-nostartfiles",
+    "-C", "link-arg=-Tmsp430g2553.ld",
+    "-C", "link-arg=-mmcu=msp430g2553",
+    "-C", "link-arg=-nostartfiles",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+build = "build.rs"
 name = "msp"
 version = "0.1.0"
 authors = ["Vadzim Dambrouski <pftbest@gmail.com>"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("msp430g2553.ld"))
+        .unwrap()
+        .write_all(include_bytes!("ldscripts/msp430g2553.ld"))
+        .unwrap();
+    File::create(out.join("msp430g2553_symbols.ld"))
+        .unwrap()
+        .write_all(include_bytes!("ldscripts/msp430g2553_symbols.ld"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=ldscripts/msp430g2553.ld");
+    println!("cargo:rerun-if-changed=ldscripts/msp430g2553_symbols.ld");
+}

--- a/msp-gcc.sh
+++ b/msp-gcc.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-msp430-elf-gcc -mmcu=msp430g2553 $@

--- a/msp430.json
+++ b/msp430.json
@@ -1,7 +1,9 @@
 {
   "arch": "msp430",
+  "asm-args": ["-mcpu=msp430"],
   "data-layout": "e-m:e-p:16:16-i32:16:32-a:16-n8:16",
   "executables": true,
+  "linker": "msp430-elf-gcc",
   "llvm-target": "msp430",
   "max-atomic-width": 0,
   "no-integrated-as": true,


### PR DESCRIPTION
Using the new asm-args field introduced in rust-lang/rust#38463, we can
fix the ABI problem in the target specification itself.

As the shim is gone, now the -mmcu flag is passed to the linker using
.cargo/config.

This commit also adds a build script. This build script will copy the
linker scripts from the ldscripts directory to $OUT_DIR. This (a) lets
you call the cargo command from a directory different that the root of
the Cargo project and (b) opens the possibility of using this crate as a
library.

---

r? @pftbest I didn't update the README. I'll leave that to you :smile:. Also this depends on rust-lang/rust#38463.