### PR TITLE
Add linker-flavor

### DIFF
--- a/msp430.json
+++ b/msp430.json
@@ -4,6 +4,7 @@
   "data-layout": "e-m:e-p:16:16-i32:16:32-a:16-n8:16",
   "executables": true,
   "linker": "msp430-elf-gcc",
+  "linker-flavor": "gcc",
   "llvm-target": "msp430",
   "max-atomic-width": 0,
   "no-integrated-as": true,


### PR DESCRIPTION
With newer rustc you need to specify the linker flavor and this makes it build again on my board. 

Thanks for the very helpful template!